### PR TITLE
minor v4l2 API tweak to avoid possible warning

### DIFF
--- a/kernel/sur40.c
+++ b/kernel/sur40.c
@@ -791,8 +791,10 @@ static int sur40_vidioc_fmt(struct file *file, void *priv,
 static int sur40_ioctl_parm(struct file *file, void *priv,
 			    struct v4l2_streamparm *p)
 {
-	p->parm.capture.timeperframe.numerator = 1;
-	p->parm.capture.timeperframe.denominator = 60;
+	if (p->type == V4L2_BUF_TYPE_VIDEO_CAPTURE) {
+		p->parm.capture.timeperframe.numerator = 1;
+		p->parm.capture.timeperframe.denominator = 60;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
just a simple v4l2 parm type check,
which hopefully avoids possible warnings,
to keep the maintainers happy ...