### PR TITLE
heureka (fixes random crashes on device close)

### DIFF
--- a/kernel/sur40.c
+++ b/kernel/sur40.c
@@ -126,7 +126,7 @@ struct sur40_image_header {
 #define VIDEO_PACKET_SIZE  16384
 
 /* polling interval (ms) */
-#define POLL_INTERVAL 4
+#define POLL_INTERVAL 1
 
 /* maximum number of contacts FIXME: this is a guess? */
 #define MAX_CONTACTS 64
@@ -448,7 +448,7 @@ static void sur40_process_video(struct sur40_state *sur40)
 
 	/* return error if streaming was stopped in the meantime */
 	if (sur40->sequence == -1)
-		goto err_poll;
+		return;
 
 	/* mark as finished */
 	new_buf->vb.vb2_buf.timestamp = ktime_get_ns();
@@ -736,6 +736,7 @@ static int sur40_start_streaming(struct vb2_queue *vq, unsigned int count)
 static void sur40_stop_streaming(struct vb2_queue *vq)
 {
 	struct sur40_state *sur40 = vb2_get_drv_priv(vq);
+	vb2_wait_for_all_buffers(vq);
 	sur40->sequence = -1;
 
 	/* Release all active buffers */


### PR DESCRIPTION
* finally fix kernel crashes and freezing by waiting for all buffers to finish:
  vb2_wait_for_all_buffers() was actually suggested in the videobuf2-core header
* no need then to return buffers again if streaming was already finished
* reduce POLL_INTERVAL to 1ms: increases actual frame rate from 56-58 to full 60fps
  and should also decrease the overall latency a tiny bit
  ... I guess this is justified, since this is an essential driver on this platform
