### PR TITLE
update to avoid v4l2-compliance warnings

### DIFF
--- a/kernel/sur40.c
+++ b/kernel/sur40.c
@@ -793,10 +793,12 @@ static int sur40_ioctl_parm(struct file *file, void *priv,
 			    struct v4l2_streamparm *p)
 {
 	if (p->type == V4L2_BUF_TYPE_VIDEO_CAPTURE) {
+		p->parm.capture.capability = V4L2_CAP_TIMEPERFRAME;
 		p->parm.capture.timeperframe.numerator = 1;
 		p->parm.capture.timeperframe.denominator = 60;
-	}
-	return 0;
+		p->parm.capture.readbuffers = 1;
+		return 0;
+	} else return -EINVAL;
 }
 
 static int sur40_vidioc_enum_fmt(struct file *file, void *priv,


### PR DESCRIPTION
this adds the necessary corrections as suggested by the kernel maintainers, and has been also checked with the v4l2-compliance tool (from v4l-utils)

the according test passes without any error or warning,  although the according function still may need to return the actual number of buffers, which is now just set to 1. in the case of my application, this doesn't matter though.